### PR TITLE
fix: Map overlay + JSON load crash

### DIFF
--- a/src/data/units/scout_plt_1a111_acr.json
+++ b/src/data/units/scout_plt_1a111_acr.json
@@ -66,15 +66,6 @@
   "role": "RECON",
   "size": 3,
   "stats": {
-<<<<<<< HEAD
-	"attack": 72.64,
-	"defense": 15.0,
-	"morale": 1.0,
-	"range_m": 400.0,
-	"speed_kph": 60.0,
-	"spot_m": 1600.0,
-	"understrength_threshold": 0.8
-=======
 	"attack": 36.24,
 	"defense": 15.0,
 	"morale": 1.0,
@@ -82,7 +73,6 @@
 	"speed_kph": 60.0,
 	"spot_m": 1600.0,
 	"understrength_threshold": 0.8
->>>>>>> main
   },
   "strength": 28,
   "supply_transfer_radius_m": 30.0,

--- a/src/scenes/ui/viewport_read_overlay.tscn
+++ b/src/scenes/ui/viewport_read_overlay.tscn
@@ -17,7 +17,7 @@ anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 mouse_filter = 0
-color = Color(0, 0, 0, 0.65)
+color = Color(0, 0, 0, 1)
 
 [node name="Margin" type="MarginContainer" parent="Root"]
 anchors_preset = 15


### PR DESCRIPTION
Fix map inspect overlay background + avoid forced full-res scaling Remove merge conflict markers from scout_plt_1a111_acr.json to restore JSON parsing

## When merged this pull request will:
- Fixes map inspect overlay background so it no longer “breaks” the scene behind it
- Keeps map inspect readable without forcing full-res render scaling
- Fixes a crash/parse error by removing leftover merge conflict markers from src/data/units/scout_plt_1a111_acr.json

## Issue ticket number and link
No issue linked

## Checklist before requesting a review
- [X] I have performed a self-review of my code.
- [X] I have tested my code.
- [X] I have documented my code in accordance with [gdscript_documentation_comments](https://docs.godotengine.org/en/4.5/tutorials/scripting/gdscript/gdscript_documentation_comments.html).
- [X] I have requested a review in discord.
- [X] I have moved the related issues to the review section in the [SCRUM Board](https://github.com/orgs/operationalCommandTeam/projects/1).